### PR TITLE
escape attribute names

### DIFF
--- a/src/main/java/net/thornydev/JsonHiveSchema.java
+++ b/src/main/java/net/thornydev/JsonHiveSchema.java
@@ -13,42 +13,42 @@ import org.json.JSONObject;
 /**
  * Generates Hive schemas for use with the JSON SerDe from
  * org.openx.data.jsonserde.JsonSerDe.  GitHub link: https://github.com/rcongiu/Hive-JSON-Serde
- * 
+ *
  * Pass in a valid JSON document string to {@link JsonHiveSchema#createHiveSchema} and it will
  * return a Hive schema for the JSON document.
- * 
+ *
  * It supports embedded JSON objects, arrays and the standard JSON scalar types: strings,
  * numbers, booleans and null.  You probably don't want null in the JSON document you provide
- * as Hive can't use that.  For numbers - if the example value has a decimal, it will be 
+ * as Hive can't use that.  For numbers - if the example value has a decimal, it will be
  * typed as "double".  If the number has no decimal, it will be typed as "int".
- * 
+ *
  * This program uses the JSON parsing code from json.org and that code is included in this
  * library, since it has not been packaged and made available for maven/ivy/gradle dependency
  * resolution.
- * 
+ *
  * <strong>Use of main method:</strong> <br>
  *   JsonHiveSchema has a main method that takes a file path to a JSON doc - this file should have
  *   only one JSON file in it.  An optional second argument can be provided to name the Hive table
  *   that is generated.
  */
 public class JsonHiveSchema  {
-  
+
   static void help() {
     System.out.println("Usage: Two arguments possible. First is required. Second is optional");
     System.out.println("  1st arg: path to JSON file to parse into Hive schema");
     System.out.println("  2nd arg (optional): tablename.  Defaults to 'x'");
   }
-  
+
   public static void main( String[] args ) throws Exception {
     if (args.length == 0) {
       throw new IllegalArgumentException("ERROR: No file specified");
     }
-    
+
     if (args[0].equals("-h")) {
       help();
       System.exit(0);
     }
-    
+
     StringBuilder sb = new StringBuilder();
     BufferedReader br = new BufferedReader( new FileReader(args[0]) );
     String line;
@@ -56,7 +56,7 @@ public class JsonHiveSchema  {
       sb.append(line).append("\n");
     }
     br.close();
-    
+
     String tableName = "x";
     if (args.length == 2) {
       tableName = args[1];
@@ -65,31 +65,31 @@ public class JsonHiveSchema  {
     JsonHiveSchema schemaWriter = new JsonHiveSchema(tableName);
     System.out.println(schemaWriter.createHiveSchema(sb.toString()));
   }
-  
-  
+
+
   private String tableName = "x";
-  
-  
+
+
   public JsonHiveSchema() {}
-  
+
   public JsonHiveSchema(String tableName) {
     this.tableName = tableName;
   }
-  
+
   /**
    * Pass in any valid JSON object and a Hive schema will be returned for it.
    * You should avoid having null values in the JSON document, however.
-   * 
+   *
    * The Hive schema columns will be printed in alphabetical order - overall and
    * within subsections.
-   * 
+   *
    * @param json
    * @return string Hive schema
    * @throws JSONException if the JSON does not parse correctly
    */
   public String createHiveSchema(String json) throws JSONException {
     JSONObject jo = new JSONObject(json);
-    
+
     @SuppressWarnings("unchecked")
     Iterator<String> keys = jo.keys();
     keys = new OrderedIterator(keys);
@@ -98,7 +98,7 @@ public class JsonHiveSchema  {
     while (keys.hasNext()) {
       String k = keys.next();
       sb.append("  ");
-      sb.append(k.toString());
+      sb.append(escapedKey(k));
       sb.append(' ');
       sb.append(valueToHiveSchema(jo.opt(k)));
       sb.append(',').append("\n");
@@ -108,15 +108,19 @@ public class JsonHiveSchema  {
     return sb.append("ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe';").toString();
   }
 
-  private String toHiveSchema(JSONObject o) throws JSONException { 
+  private String escapedKey(String key) {
+    return '`' + key.toString() + '`';
+  }
+
+  private String toHiveSchema(JSONObject o) throws JSONException {
     @SuppressWarnings("unchecked")
     Iterator<String> keys = o.keys();
     keys = new OrderedIterator(keys);
     StringBuilder sb = new StringBuilder("struct<");
-    
+
     while (keys.hasNext()) {
       String k = keys.next();
-      sb.append(k.toString());
+      sb.append(escapedKey(k));
       sb.append(':');
       sb.append(valueToHiveSchema(o.opt(k)));
       sb.append(", ");
@@ -135,18 +139,18 @@ public class JsonHiveSchema  {
     if (a.length() == 0) {
       throw new IllegalStateException("Array is empty: " + a.toString());
     }
-    
+
     Object entry0 = a.get(0);
     if ( isScalar(entry0) ) {
       sb.append( scalarType(entry0) );
     } else if (entry0 instanceof JSONObject) {
       sb.append( toHiveSchema((JSONObject)entry0) );
-    } else if (entry0 instanceof JSONArray) {    
+    } else if (entry0 instanceof JSONArray) {
       sb.append( toHiveSchema((JSONArray)entry0) );
     }
     return sb.toString();
   }
-  
+
   private String scalarType(Object o) {
     if (o instanceof String) return "string";
     if (o instanceof Number) return scalarNumericType(o);
@@ -166,7 +170,7 @@ public class JsonHiveSchema  {
   private boolean isScalar(Object o) {
     return o instanceof String ||
         o instanceof Number ||
-        o instanceof Boolean || 
+        o instanceof Boolean ||
         o == JSONObject.NULL;
   }
 
@@ -181,11 +185,11 @@ public class JsonHiveSchema  {
       throw new IllegalArgumentException("unknown type: " + o.getClass());
     }
   }
-  
+
   static class OrderedIterator implements Iterator<String> {
 
     Iterator<String> it;
-    
+
     public OrderedIterator(Iterator<String> iter) {
       SortedSet<String> keys = new TreeSet<String>();
       while (iter.hasNext()) {
@@ -193,7 +197,7 @@ public class JsonHiveSchema  {
       }
       it = keys.iterator();
     }
-    
+
     public boolean hasNext() {
       return it.hasNext();
     }


### PR DESCRIPTION
escape all table attribute names with backticks by default, in order to avoid SQL errors with special characters (such as leading underscore characters) in attribute names.
