### PR TITLE
Use backticks to escape names

### DIFF
--- a/src/main/java/net/thornydev/JsonHiveSchema.java
+++ b/src/main/java/net/thornydev/JsonHiveSchema.java
@@ -98,7 +98,9 @@ public class JsonHiveSchema  {
     while (keys.hasNext()) {
       String k = keys.next();
       sb.append("  ");
-      sb.append(k.toString());
+      sb.append("`");
+      sb.append(k.toString().replace("`", "``"));
+      sb.append("`");
       sb.append(' ');
       sb.append(valueToHiveSchema(jo.opt(k)));
       sb.append(',').append("\n");
@@ -116,7 +118,9 @@ public class JsonHiveSchema  {
     
     while (keys.hasNext()) {
       String k = keys.next();
-      sb.append(k.toString());
+      sb.append("`");
+      sb.append(k.toString().replace("`", "``"));
+      sb.append("`");
       sb.append(':');
       sb.append(valueToHiveSchema(o.opt(k)));
       sb.append(", ");


### PR DESCRIPTION
This commit wraps all names in backticks so they are interpreted literally and do not break on reserved words. Literal backticks are escaped with a second backtick.
